### PR TITLE
Bump to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ desired.
 No trailing slash should be provided to `source_path`.
 
     certs::vhost { 'www.example.com':
-      source_path => 'puppet:///site_certificates',
+      source_path => 'puppet:///modules/site_certificates',
     }
 
 Creates `/etc/ssl/certs/www.example.com.crt` and
@@ -44,7 +44,7 @@ Creates `/etc/ssl/certs/www.example.com.crt` and
 
     certs::vhost { 'www.example.com':
       target_path => '/etc/httpd/ssl.d',
-      source_path => 'puppet:///site_certificates',
+      source_path => 'puppet:///modules/site_certificates',
     }
 
 Creates the same crt and key files in `/etc/httpd/ssl.d`.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -38,14 +38,15 @@
 #
 #    server.yaml
 #    ---
-#    certs::vhost::source_path: 'puppet:///site_certificates'
 #    certsvhost:
-#      'www.example.com': {}
+#      'www.example.com':
+#        source_path: 'puppet:///modules/site_certificates/'
 #
 #    manifest.pp
+#    ---
 #    certsvhost = hiera_hash('certsvhost')
 #    create_resources(certs::vhost, certsvhost)
-#    Certs::vhost<| |> -> Apache::vhost<| |>
+#    Certs::Vhost<| |> -> Apache::Vhost<| |>
 #
 # === Authors
 #

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "rnelson0-certs",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": "rnelson0",
   "summary": "SSL Certificate File Management",
   "license": "Apache 2.0",


### PR DESCRIPTION
Documentation update:
  Use correct puppet:// URI for a module's files
  Hiera sample code tweaks

Addresses issue #8 
