### PR TITLE
Add features: base64 from Vault, different cert and key paths, file_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,32 @@ Creates the same crt and key files in `/etc/httpd/ssl.d`.
 
     Certs::Vhost<| |> -> Apache::Vhost<| |>
 
+If you wish for your certificate and key to go to different paths, you can specify them accordingly.  If one or bothof these values are not passed, `target_path` will be used.
+
+    certs::vhost { 'www.example.com':
+      crt_target_path => '/etc/pki/certs',
+      key_target_path => '/etc/pki/private',
+      source_path => 'puppet:///modules/site_certificates',
+    }
+
 When providing the certificate files to the `apache::vhost` or similar classes
 it is best to ensure they are properly dependent upon the `certs::vhost`.
 
-To use the vault options, you must have a module that is API compatible with [puppet-vault_lookup](https://forge.puppet.com/puppet/vault_lookup) installed. If you are not using vault, this dependency is optional.
+To use the vault options, you must have a module that is API compatible with [puppet-vault_lookup](https://forge.puppet.com/puppet/vault_lookup) installed. If you are not using vault, this dependency is optional.  Some types of certificates may have been encoded with base64 for compatibility with Vault, you can specify `base64_vault_crt` to decode this certificate type.
 
     certs::vhost { 'www.example.com':
-      target_path => '/etc/httpd/ssl.d',
-      source_path => '/v1/kv/puppet/ssl',
-      vault       => true,
+      target_path      => '/etc/httpd/ssl.d',
+      source_path      => '/v1/kv/puppet/ssl',
+      vault            => true,
+      base64_vault_crt => true,
     }
 
+You can optionally specify file options such as owner and mode by using the `file_options` variable.
+
+    certs::vhost { 'www.example.com':
+      target_path  => '/etc/httpd/ssl.d',
+      source_path  => 'puppet:///modules/site_certificates',
+      file_options => { owner => 'root',
+                        group => 'root',
+                        mode  => '0644',}
+    }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -42,8 +42,8 @@ define certs::vhost (
   String $source_name               = $name,
   String $source_path               = undef,
   String $target_path               = '/etc/ssl/certs',
-  String $crt_target_path           = undef,
-  String $key_target_path           = undef,
+  String $crt_target_path           = '',
+  String $key_target_path           = '',
   String $service                   = 'httpd',
   Boolean $vault                    = false,
   Boolean $notify_service           = true,
@@ -61,13 +61,13 @@ define certs::vhost (
   $key_name = "${name}.key"
 
 
-  if $crt_target_path {
+  if $crt_target_path != '' {
     $crt_target_path_final = $crt_target_path
   }
   else {
     $crt_target_path_final = $target_path
   }
-  if $key_target_path {
+  if $key_target_path != '' {
     $key_target_path_final = $key_target_path
   }
   else {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -45,7 +45,7 @@ define certs::vhost (
   String $crt_target_path           = undef,
   String $key_target_path           = undef,
   String $service                   = 'httpd',
-  Boolean $vault                    = undef,
+  Boolean $vault                    = false,
   Boolean $notify_service           = true,
   Enum['crt','pem'] $cert_extension = 'crt',
   Hash $file_options                = {},

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -56,19 +56,25 @@ define certs::vhost (
   if ($source_path == undef) {
     fail('You must provide a source_path for the SSL files to certs::vhost.')
   }
-  if ($target_path == undef) {
-    fail('You must provide a target_ path for the certs to certs::vhost.')
+  if ($target_path == undef and $crt_target_path == undef and $key_target_path == undef) {
+    fail('You must provide a target_path or key_target_path and crt_target_path for the certs to certs::vhost.')
   }
 
   $cert_name = "${name}.${cert_extension}"
   $key_name = "${name}.key"
 
 
-  if $crt_target_path == undef {
-    $crt_target_path = $target_path
+  if $crt_target_path {
+    $crt_target_path_final = $crt_target_path
   }
-  if $key_target_path == undef {
-    $key_target_path = $target_path
+  else {
+    $crt_target_path_final = $target_path
+  }
+  if $key_target_path {
+    $key_target_path_final = $key_target_path
+  }
+  else {
+    $key_target_path_final = $target_path
   }
 
 
@@ -77,13 +83,13 @@ define certs::vhost (
 
     file { $cert_name:
       ensure  => file,
-      path    => "${crt_target_path}/${cert_name}",
+      path    => "${crt_target_path_final}/${cert_name}",
       content => inline_epp('<%= $data %>', {'data' => $vault_ssl_hash['crt']}),
       * => $file_options
     }
     -> file { $key_name:
       ensure  => file,
-      path    => "${key_target_path}/${key_name}",
+      path    => "${key_target_path_final}/${key_name}",
       content => inline_epp('<%= $data %>', {'data' => $vault_ssl_hash['key']}),
       * => $file_options
     }
@@ -91,13 +97,13 @@ define certs::vhost (
   else {
     file { $cert_name:
       ensure => file,
-      path   => "${crt_target_path}/${cert_name}",
+      path   => "${crt_target_path_final}/${cert_name}",
       source => "${source_path}/${source_name}.crt",
       * => $file_options
     }
     -> file { $key_name:
       ensure => file,
-      path   => "${key_target_path}/${key_name}",
+      path   => "${key_target_path_final}/${key_name}",
       source => "${source_path}/${source_name}.key",
       * => $file_options
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -39,16 +39,16 @@
 #  Use vault_lookup to query vault service for crt/key pair
 #  Default: 'undef'
 define certs::vhost (
-  String $source_name                      = $name,
-  String $source_path                      = undef,
-  String $target_path                      = '/etc/ssl/certs',
-  String $crt_target_path                  = undef,
-  String $key_target_path                  = undef,
-  String $service                          = 'httpd',
-  Bool $vault                            = undef,
-  Bool $notify_service                   = true,
+  String $source_name               = $name,
+  String $source_path               = undef,
+  String $target_path               = '/etc/ssl/certs',
+  String $crt_target_path           = undef,
+  String $key_target_path           = undef,
+  String $service                   = 'httpd',
+  Boolean $vault                    = undef,
+  Boolean $notify_service           = true,
   Enum['crt','pem'] $cert_extension = 'crt',
-  Hash $file_options                     = {},
+  Hash $file_options                = {},
 ) {
   if ($name == undef) {
     fail('You must provide a name value for the vhost to certs::vhost.')

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -46,7 +46,7 @@ define certs::vhost (
   $vault                            = undef,
   $notify_service                   = true,
   Enum['crt','pem'] $cert_extension = 'crt',
-  $file_options                     = {}
+  $file_options                     = {},
 ) {
   if ($name == undef) {
     fail('You must provide a name value for the vhost to certs::vhost.')

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -46,6 +46,7 @@ define certs::vhost (
   $vault                            = undef,
   $notify_service                   = true,
   Enum['crt','pem'] $cert_extension = 'crt',
+  $file_options                     = {}
 ) {
   if ($name == undef) {
     fail('You must provide a name value for the vhost to certs::vhost.')
@@ -67,11 +68,13 @@ define certs::vhost (
       ensure  => file,
       path    => "${target_path}/${cert_name}",
       content => inline_epp('<%= $data %>', {'data' => $vault_ssl_hash['crt']}),
+      * => $file_options
     }
     -> file { $key_name:
       ensure  => file,
       path    => "${target_path}/${key_name}",
       content => inline_epp('<%= $data %>', {'data' => $vault_ssl_hash['key']}),
+      * => $file_options
     }
   }
   else {
@@ -79,11 +82,13 @@ define certs::vhost (
       ensure => file,
       path   => "${target_path}/${cert_name}",
       source => "${source_path}/${source_name}.crt",
+      * => $file_options
     }
     -> file { $key_name:
       ensure => file,
       path   => "${target_path}/${key_name}",
       source => "${source_path}/${source_name}.key",
+      * => $file_options
     }
   }
   if $notify_service { Certs::Vhost[$title] ~> Service[$service] }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -42,6 +42,8 @@ define certs::vhost (
   $source_name                      = $name,
   $source_path                      = undef,
   $target_path                      = '/etc/ssl/certs',
+  $crt_target_path                  = undef,
+  $key_target_path                  = undef,
   $service                          = 'httpd',
   $vault                            = undef,
   $notify_service                   = true,
@@ -61,18 +63,27 @@ define certs::vhost (
   $cert_name = "${name}.${cert_extension}"
   $key_name = "${name}.key"
 
+
+  if $crt_target_path == undef {
+    $crt_target_path = $target_path
+  }
+  if $key_target_path == undef {
+    $key_target_path = $target_path
+  }
+
+
   if $vault {
     $vault_ssl_hash = vault_lookup("${source_path}/${source_name}")
 
     file { $cert_name:
       ensure  => file,
-      path    => "${target_path}/${cert_name}",
+      path    => "${crt_target_path}/${cert_name}",
       content => inline_epp('<%= $data %>', {'data' => $vault_ssl_hash['crt']}),
       * => $file_options
     }
     -> file { $key_name:
       ensure  => file,
-      path    => "${target_path}/${key_name}",
+      path    => "${key_target_path}/${key_name}",
       content => inline_epp('<%= $data %>', {'data' => $vault_ssl_hash['key']}),
       * => $file_options
     }
@@ -80,13 +91,13 @@ define certs::vhost (
   else {
     file { $cert_name:
       ensure => file,
-      path   => "${target_path}/${cert_name}",
+      path   => "${crt_target_path}/${cert_name}",
       source => "${source_path}/${source_name}.crt",
       * => $file_options
     }
     -> file { $key_name:
       ensure => file,
-      path   => "${target_path}/${key_name}",
+      path   => "${key_target_path}/${key_name}",
       source => "${source_path}/${source_name}.key",
       * => $file_options
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -56,9 +56,6 @@ define certs::vhost (
   if ($source_path == undef) {
     fail('You must provide a source_path for the SSL files to certs::vhost.')
   }
-  if ($target_path == undef and $crt_target_path == undef and $key_target_path == undef) {
-    fail('You must provide a target_path or key_target_path and crt_target_path for the certs to certs::vhost.')
-  }
 
   $cert_name = "${name}.${cert_extension}"
   $key_name = "${name}.key"

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -39,16 +39,16 @@
 #  Use vault_lookup to query vault service for crt/key pair
 #  Default: 'undef'
 define certs::vhost (
-  $source_name                      = $name,
-  $source_path                      = undef,
-  $target_path                      = '/etc/ssl/certs',
-  $crt_target_path                  = undef,
-  $key_target_path                  = undef,
-  $service                          = 'httpd',
-  $vault                            = undef,
-  $notify_service                   = true,
+  String $source_name                      = $name,
+  String $source_path                      = undef,
+  String $target_path                      = '/etc/ssl/certs',
+  String $crt_target_path                  = undef,
+  String $key_target_path                  = undef,
+  String $service                          = 'httpd',
+  Bool $vault                            = undef,
+  Bool $notify_service                   = true,
   Enum['crt','pem'] $cert_extension = 'crt',
-  $file_options                     = {},
+  Hash $file_options                     = {},
 ) {
   if ($name == undef) {
     fail('You must provide a name value for the vhost to certs::vhost.')


### PR DESCRIPTION
- Update types and defaults for variables
- Add support for base64 decoding certificates from Vault, useful for DER certificates and other types that cannot be stored in plain text in Vault
- Add support for certs and keys to have different target paths
- Add support for overriding file options